### PR TITLE
E2459. View for results of bidding

### DIFF
--- a/app/services/bidding_summary_service.rb
+++ b/app/services/bidding_summary_service.rb
@@ -27,7 +27,7 @@ class BiddingSummaryService
       # Calculate the percentage of first priority bids.
       percentage_first = if total_bids > 0
                            # If there are any bids, calculate the percentage.
-                           (first_bids.to_f / total_bids * 100).round(2)
+                           (first_choice_bids.to_f / total_bids * 100).round(2)
                          else
                            # If there are no bids, the percentage is 0.
                            0

--- a/app/views/bidding_teams/bidding_summary.html.erb
+++ b/app/views/bidding_teams/bidding_summary.html.erb
@@ -47,9 +47,9 @@
         <!-- Display topic id, name, bid counts, total bids, and bidding teams -->
         <td><%= topic[:id] %></td>
         <td><%= topic[:name] %></td>
-        <td><%= topic[:first_bids] %></td>
-        <td><%= topic[:second_bids] %></td>
-        <td><%= topic[:third_bids] %></td>
+        <td><%= topic[:first_choice_bids] %></td>
+        <td><%= topic[:second_choice_bids] %></td>
+        <td><%= topic[:third_choice_bids] %></td>
         <td><%= topic[:total_bids] %></td>
         <!-- Calculate and display the percentage of first bids with tooltip and custom background -->
         <td title="Calculated as (#1 Bids / Total Bids) * 100">


### PR DESCRIPTION
In bidding summary view, updated references as follows:
first_bids ==> first_choice_bids
second_bids ==> second_choice_bids
third_bids ==> third_choice_bids

---
About the Expertiza Bot
- If you have any questions about comments given by the expertiza-bot [(example)](https://github.com/expertiza/expertiza/pull/1877#issuecomment-762412918), you could create a new comment in your pull request with the content `/dispute [UUID1] [UUID2]` [(example)](https://github.com/expertiza/expertiza/pull/1877#issuecomment-762430057), then the professor and TAs will be notified.
- [Here is a video](https://tinyurl.com/internet-bots) about how to communicate to the expertiza-bot.
