### PR TITLE
E2485. Refactor ReviewBidsController#action_allowed? to Align with SignUpController Logic

### DIFF
--- a/app/controllers/review_bids_controller.rb
+++ b/app/controllers/review_bids_controller.rb
@@ -14,9 +14,10 @@ class ReviewBidsController < ApplicationController
   def action_allowed?
     case params[:action]
     when 'show', 'set_priority', 'index'
-      required_role_for_show_actions? && list_action_authorized?(params[:id])
+      (current_user_has_student_privileges? && list_action_authorized?) ||
+        current_user_has_student_privileges?
     else
-      required_role_for_other_actions?
+      current_user_has_ta_privileges?
     end
   end
 
@@ -127,7 +128,7 @@ class ReviewBidsController < ApplicationController
   end
 
   def list_action_authorized?(assignment_id)
-    action_name != 'list' || are_needed_authorizations_present?(assignment_id, required_roles_for_list)
+    (%w[list].include? action_name) && are_needed_authorizations_present?(assignment_id, required_roles_for_list)
   end
 
   def required_roles_for_list

--- a/config/database.yml.example
+++ b/config/database.yml.example
@@ -2,7 +2,7 @@ default: &default
   adapter: mysql2
   host: localhost
   username: root
-  password: 
+  password: expertiza
   encoding: utf8
   collation: utf8_general_ci
 


### PR DESCRIPTION
Refactored the action_allowed? method in `ReviewBidsController` to align with the logic used in `SignUpController`.

- Roles with a value of 1 or higher are treated as having student privileges.
- Roles with a value of 2 or higher are treated as having TA privileges.

**Key Changes:**
- Updated `ReviewBidsController#action_allowed?` to use privilege logic based on role values (1 for student, 2 for TA).
- Ensured consistency with `SignUpController` role handling.

---
About the Expertiza Bot
- If you have any questions about comments given by the expertiza-bot [(example)](https://github.com/expertiza/expertiza/pull/1877#issuecomment-762412918), you could create a new comment in your pull request with the content `/dispute [UUID1] [UUID2]` [(example)](https://github.com/expertiza/expertiza/pull/1877#issuecomment-762430057), then the professor and TAs will be notified.
- [Here is a video](https://tinyurl.com/internet-bots) about how to communicate to the expertiza-bot.
