### PR TITLE
E2485. Code Cleanup and Streamline `action_allowed` methods across controllers

### DIFF
--- a/app/controllers/concerns/action_authorization_concern.rb
+++ b/app/controllers/concerns/action_authorization_concern.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+# The `ActionAuthorizationConcern` module provides shared authorization logic
+# for controllers that require role-based access checks for specific actions.
+# It defines the `action_authorized?` method, which checks whether the necessary
+# authorizations are present for a given action and assignment.
+#
+# Including controllers must implement the `required_authorizations_for_action` method
+# to define the authorizations needed for the actions within their specific context.
+module ActionAuthorizationConcern
+  extend ActiveSupport::Concern
+
+  # Determines if the current action is authorized for the given assignment
+  def action_authorized?(assignment_id)
+    allowed_actions_for_roles.include?(action_name) &&
+      are_needed_authorizations_present?(assignment_id, required_authorizations_for_actions)
+  end
+
+  # List of actions allowed for specific roles
+  def allowed_actions_for_authorizations
+    %w[list]
+  end
+
+  # Authorizations required for specific actions
+  def required_authorizations_for_actions
+    raise NotImplementedError, 'You must implement `required_authorizations_for_action` in the including controller'
+  end
+end

--- a/app/services/participant_service.rb
+++ b/app/services/participant_service.rb
@@ -5,6 +5,8 @@
 # retrieve associated assignment details, determine the current topic ID, and fetch
 # the reviewer associated with the participant.
 class ParticipantService
+  attr_reader :participant, :assignment
+
   def initialize(participant_id, current_user_id)
     @participant = AssignmentParticipant.find(participant_id)
     @current_user_id = current_user_id

--- a/app/services/review_service.rb
+++ b/app/services/review_service.rb
@@ -3,6 +3,8 @@
 # The `ReviewService` class encapsulates the business logic related to managing
 # review mappings for a given participant and their associated assignment.
 class ReviewService
+  attr_reader :participant, :assignment, :reviewer
+
   def initialize(participant)
     @participant = participant
     @assignment = participant.assignment


### PR DESCRIPTION
Remove obsolete methods from the `ReviewBidsController` and streamline `action_allowed` methods across controllers.

**Change Summary**
Removed obsolete methods from ReviewBidsController
Streamline action_allowed methods across three controllers.
---
About the Expertiza Bot
- If you have any questions about comments given by the expertiza-bot [(example)](https://github.com/expertiza/expertiza/pull/1877#issuecomment-762412918), you could create a new comment in your pull request with the content `/dispute [UUID1] [UUID2]` [(example)](https://github.com/expertiza/expertiza/pull/1877#issuecomment-762430057), then the professor and TAs will be notified.
- [Here is a video](https://tinyurl.com/internet-bots) about how to communicate to the expertiza-bot.
