### PR TITLE
E2485. Centralize and improve action authorization logic

### DIFF
--- a/app/controllers/concerns/participant_service_concern.rb
+++ b/app/controllers/concerns/participant_service_concern.rb
@@ -1,18 +1,11 @@
 # frozen_string_literal: true
 
-# This concern provides the `participant_service` method and related participant-specific logic.
+# This concern provides the `participant_service` method.
 module ParticipantServiceConcern
   extend ActiveSupport::Concern
 
   # Initialize participant service
   def participant_service
     @participant_service ||= ParticipantService.new(params[:id], current_user.id)
-  end
-
-  private
-
-  # Check if the user is a valid participant
-  def authorize_participant
-    head :forbidden unless participant_service.valid_participant?
   end
 end

--- a/app/services/participant_service.rb
+++ b/app/services/participant_service.rb
@@ -5,7 +5,7 @@
 # retrieve associated assignment details, determine the current topic ID, and fetch
 # the reviewer associated with the participant.
 class ParticipantService
-  attr_reader :participant, :assignment
+  attr_reader :participant
 
   def initialize(participant_id, current_user_id)
     @participant = AssignmentParticipant.find(participant_id)
@@ -13,18 +13,24 @@ class ParticipantService
   end
 
   def valid_participant?
+    return false unless @participant
+
     @participant.user_id == @current_user_id
   end
 
   def assignment
-    @participant.assignment
+    @assignment ||= @participant&.assignment
   end
 
   def topic_id
-    SignedUpTeam.topic_id(@participant.parent_id, @participant.user_id)
+    SignedUpTeam.topic_id(@participant&.parent_id, @participant&.user_id)
   end
 
   def reviewer
-    @participant.get_reviewer
+    @participant&.get_reviewer
+  end
+
+  def participant_authorization
+    @participant&.authorization
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -72,18 +72,18 @@ RSpec.configure do |config|
   #   # rspec-expectations config goes here. You can use an alternate
   #   # assertion/expectation library such as wrong or the stdlib/minitest
   #   # assertions if you prefer.
-     config.expect_with :rspec do |expectations|
-       # Enable only the newer, non-monkey-patching expect syntax.
-       # For more details, see:
-       #   - http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax
-       expectations.syntax = :expect
-       
-       RSpec.configure do |rspec|
-         rspec.expect_with :rspec do |c|
-           c.max_formatted_output_length = nil
-         end
-       end  
-   end
+  config.expect_with :rspec do |expectations|
+    # Enable only the newer, non-monkey-patching expect syntax.
+    # For more details, see:
+    #   - http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax
+    expectations.syntax = :expect
+
+    RSpec.configure do |rspec|
+      rspec.expect_with :rspec do |c|
+        c.max_formatted_output_length = nil
+      end
+    end
+  end
   #
   #   # rspec-mocks config goes here. You can use an alternate test double
   #   # library (such as bogus or mocha) by changing the `mock_with` option here.


### PR DESCRIPTION
**Change Summary**
- Moved `action_allowed` logic from `ReviewBidsController` and `StudentReviewController` to `ActionAuthorizationConcern`
- Added `before_action` for `authorize_action` in both controllers and implemented supporting private methods
- Cleaned up action authorization within `ActionAuthorizationConcern` for better maintainability
- Relocated `authorize_participant` method from `ParticipantServiceConcern` to `ActionAuthorizationConcern`
- Introduced Safe Navigation Operator (`&.`) in `participant_service` for safer participant access
- Added tests for `ReviewBidsController` to ensure authorization works as expected but those tests need to be refactored

**Reviewers**
@efg 
@gavint7 
---
About the Expertiza Bot
- If you have any questions about comments given by the expertiza-bot [(example)](https://github.com/expertiza/expertiza/pull/1877#issuecomment-762412918), you could create a new comment in your pull request with the content `/dispute [UUID1] [UUID2]` [(example)](https://github.com/expertiza/expertiza/pull/1877#issuecomment-762430057), then the professor and TAs will be notified.
- [Here is a video](https://tinyurl.com/internet-bots) about how to communicate to the expertiza-bot.
