### PR TITLE
Set up BiddingAssignmentService and update ReviewBidController#assign_bidding method to use service instead

### DIFF
--- a/app/models/review_bid.rb
+++ b/app/models/review_bid.rb
@@ -41,17 +41,12 @@ class ReviewBid < ApplicationRecord
 
   # Assign topics to reviews
   def assign_review_topics(matched_topics)
-    # error handling
-    raise ArgumentError, 'Matched topics must be a Hash' unless matched_topics.is_a?(Hash)
+    validate_topics_and_assignment!(matched_topics)
 
-    # Clear existing response maps for this assignment
     ReviewResponseMap.where(reviewed_object_id: topic.assignment_id).destroy_all
 
-    # Assign topics for each reviewer
     matched_topics.each do |reviewer_id, topics|
-      Array(topics).each do |topic_id|
-        assign_topic_to_reviewer(reviewer_id, topic_id)
-      end
+      Array(topics).each { |topic_id| assign_topic_to_reviewer(reviewer_id, topic_id) }
     end
   end
 
@@ -69,5 +64,12 @@ class ReviewBid < ApplicationRecord
     # error handling
   rescue StandardError => e
     Rails.logger.error("Failed to assign topic #{topic_id} to reviewer #{reviewer_id}: #{e.message}")
+  end
+
+  private
+
+  def validate_topics_and_assignment!(matched_topics)
+    raise ArgumentError, 'Topic or assignment is missing' if topic.nil? || topic.assignment_id.nil?
+    raise ArgumentError, 'Matched topics must be a Hash' unless matched_topics.is_a?(Hash)
   end
 end

--- a/app/services/bidding_algorithm_service.rb
+++ b/app/services/bidding_algorithm_service.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+# The `BiddingAlgorithmService` run the bid assignment algorithm
+# Sends student IDs, topic IDs, student preferences, and timestamps to the web service
+# The web service returns the matched assignments in the JSON response body
+class BiddingAlgorithmService
+  SERVICE_URL = 'http://app-csc517.herokuapp.com/match_topics'.freeze
+
+  # MOCK_DATA is based on the documentation detailing how the webservice behaves.
+  # Reference: https://wiki.expertiza.ncsu.edu/index.php?title=CSC/ECE_517_Fall_2020_-_E2085._Allow_reviewers_to_bid_on_what_to_review#Webservice
+  MOCK_DATA = {
+    '36239' => [3970, 3972, 3975],
+    '36240' => [3973, 3974, 3972],
+    '36241' => [3969, 3971, 3972],
+    '36242' => [3969, 3971, 3973],
+    '36243' => [3969, 3970, 3971]
+  }.freeze
+
+  def initialize(bidding_data)
+    @bidding_data = bidding_data
+  end
+
+  def run
+    return MOCK_DATA if Rails.application.configuration.use_mock_bidding_algorithm
+
+    perform_request
+  rescue RestClient::ExceptionWithResponse, JSON::ParserError
+    false
+  end
+
+  private
+
+  def perform_request
+    response = RestClient.post(
+      SERVICE_URL,
+      @bidding_data.to_json,
+      content_type: :json,
+      accept: :json
+    )
+
+    validate_response(response)
+    JSON.parse(response.body)
+  end
+
+  def validate_response(response)
+    raise 'Invalid response format' unless response.headers[:content_type]&.include?('application/json')
+  end
+end

--- a/app/services/bidding_algorithm_service.rb
+++ b/app/services/bidding_algorithm_service.rb
@@ -9,11 +9,11 @@ class BiddingAlgorithmService
   # MOCK_DATA is based on the documentation detailing how the webservice behaves.
   # Reference: https://wiki.expertiza.ncsu.edu/index.php?title=CSC/ECE_517_Fall_2020_-_E2085._Allow_reviewers_to_bid_on_what_to_review#Webservice
   MOCK_DATA = {
-    '36239' => [3970, 3972, 3975],
-    '36240' => [3973, 3974, 3972],
-    '36241' => [3969, 3971, 3972],
-    '36242' => [3969, 3971, 3973],
-    '36243' => [3969, 3970, 3971]
+    36239 => [3970, 3972, 3975],
+    36240 => [3973, 3974, 3972],
+    36241 => [3969, 3971, 3972],
+    36242 => [3969, 3971, 3973],
+    36243 => [3969, 3970, 3971]
   }.freeze
 
   def initialize(bidding_data)
@@ -21,7 +21,7 @@ class BiddingAlgorithmService
   end
 
   def run
-    return MOCK_DATA if Rails.application.configuration.use_mock_bidding_algorithm
+    return MOCK_DATA if Rails.application.config.use_mock_bidding_algorithm
 
     perform_request
   rescue RestClient::ExceptionWithResponse, JSON::ParserError

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -55,4 +55,9 @@ Expertiza::Application.configure do
     Bullet.console = false
     Bullet.rails_logger = false
   end
+
+  # Enable mock responses for the BiddingAlgorithmService.
+  # When set to true, the service will return MOCK_DATA instead of making real HTTP requests.
+  # Reference: https://wiki.expertiza.ncsu.edu/index.php?title=CSC/ECE_517_Fall_2020_-_E2085._Allow_reviewers_to_bid_on_what_to_review#Webservice
+  config.use_mock_bidding_algorithm = true
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -33,4 +33,9 @@ Expertiza::Application.configure do
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
+
+  # Enable mock responses for the BiddingAlgorithmService.
+  # When set to true, the service will return MOCK_DATA instead of making real HTTP requests.
+  # Reference: https://wiki.expertiza.ncsu.edu/index.php?title=CSC/ECE_517_Fall_2020_-_E2085._Allow_reviewers_to_bid_on_what_to_review#Webservice
+  config.use_mock_bidding_algorithm = true  
 end

--- a/spec/controllers/review_bids_controller_spec.rb
+++ b/spec/controllers/review_bids_controller_spec.rb
@@ -246,17 +246,229 @@ describe ReviewBidsController do
 
   describe '#assign_bidding' do
     render_views
-    it 'assigns bids' do
-      get :assign_bidding
-      expect(response).to have_http_status(302) # a redirect to :back
-    end
-  end
 
-  describe '#run_bidding_algorithm' do
-    render_views
-    it 'connects to the webservice to run bidding algorithm' do
-      post :run_bidding_algorithm
-      expect(response).to have_http_status(302)
+    let(:mock_input) do
+      {
+        'tid' => [3969, 3970, 3971, 3972, 3973, 3974, 3975, 3976, 3977],
+        'users' => {
+          '36239' => {
+            'tid' => [3970, 3972],
+            'otid' => 3977,
+            'priority' => [2, 1],
+            'time' => [
+              'Thu, 12 Nov 2020 12:01:06 EST -05:00',
+              'Thu, 12 Nov 2020 12:01:07 EST -05:00'
+            ]
+          },
+          '36240' => {
+            'tid' => [],
+            'otid' => 3976,
+            'priority' => [],
+            'time' => []
+          },
+          '36241' => {
+            'tid' => [3969, 3971, 3972],
+            'otid' => 3975,
+            'priority' => [1, 3, 2],
+            'time' => [
+              'Thu, 12 Nov 2020 12:00:22 EST -05:00',
+              'Thu, 12 Nov 2020 12:00:25 EST -05:00',
+              'Thu, 12 Nov 2020 12:00:27 EST -05:00'
+            ]
+          },
+          '36242' => {
+            'tid' => [3969, 3971, 3973],
+            'otid' => 3974,
+            'priority' => [3, 2, 1],
+            'time' => [
+              'Wed, 11 Nov 2020 12:15:43 EST -05:00',
+              'Thu, 12 Nov 2020 11:59:40 EST -05:00',
+              'Thu, 12 Nov 2020 13:07:53 EST -05:00'
+            ]
+          },
+          '36243' => {
+            'tid' => [3971, 3969, 3970, 3976],
+            'otid' => 3972,
+            'priority' => [4, 3, 2, 1, 5],
+            'time' => [
+              'Wed, 11 Nov 2020 11:34:50 EST -05:00',
+              'Wed, 11 Nov 2020 12:30:16 EST -05:00',
+              'Wed, 11 Nov 2020 12:30:19 EST -05:00',
+              'Thu, 12 Nov 2020 13:02:02 EST -05:00'
+            ]
+          }
+        },
+        'max_accepted_proposals' => 3
+      }
+    end
+
+    context 'as a teaching_assistant' do
+      before do
+        controller.session[:user] = teaching_assistant
+      end
+
+      # TC01: Successful Assignment with Mock Data
+      context 'When assignment is successful' do
+        let!(:reviewers) { create_list(:participant, 5, assignment: assignment) }
+        let!(:topics) { create_list(:sign_up_topic, 5, assignment: assignment) }
+
+        let(:mock_output) do
+          reviewer_topics = reviewers.index_by(&:id)
+          reviewer_topics.transform_values { topics.sample(3).map(&:id) }
+        end
+
+        it 'assigns reviewers to topics and redirects with success' do
+          allow(Assignment).to receive(:find_by).with(id: assignment.id).and_return(assignment)
+          allow_any_instance_of(ReviewBidsController).to receive(:bidding_data).and_return(mock_input)
+          allow_any_instance_of(ReviewBidsController).to receive(:run_bidding_algorithm).and_return(mock_output)
+          allow_any_instance_of(ReviewBid).to receive(:assign_review_topics).with(mock_output).and_return(true)
+          allow(assignment).to receive(:update!).with(can_choose_topic_to_review: false).and_return(true)
+
+          # Trigger the POST action
+          post :assign_bidding, params: { assignment_id: assignment.id }
+
+          # Assert the response
+          expect(response).to have_http_status(302) # Redirection
+          expect(response).to redirect_to(root_path) # Fallback location
+          expect(flash[:notice]).to eq('Reviewers were successfully assigned to topics.') # Flash notice
+        end
+      end
+
+      # TC02: Invalid assignment_id
+      context 'when assignment_id is unsuccessful' do
+        it 'redirects back with an alert' do
+          invalid_assignment_id = -1
+          expect(ReviewBid).not_to receive(:assign_review_topics)
+          post :assign_bidding, params: { assignment_id: invalid_assignment_id }
+
+          expect(response).to have_http_status(302)
+          expect(response).to redirect_to(root_path)
+          expect(flash[:alert]).to eq('Invalid assignment. Please check and try again.')
+        end
+      end
+
+      # TC03: No Reviewers for Assignment
+      context 'when there are no reviewers for assignment' do
+        it 'redirects back with an alert' do
+          AssignmentParticipant.where(parent_id: assignment.id).destroy_all # Simulate no reviewers
+
+          expect(ReviewBid).not_to receive(:assign_review_topics)
+          post :assign_bidding, params: { assignment_id: assignment.id }
+
+          expect(response).to have_http_status(302)
+          expect(response).to redirect_to(root_path)
+          expect(flash[:alert]).to eq('No reviewers available for the assignment.')
+        end
+      end
+
+      # TC04: BiddingAlgorithmService Returns Invalid Data
+      context 'when service returns invalid data' do
+        let!(:reviewers) { create_list(:participant, 3, assignment: assignment) }
+        let(:invalid_mock_output) { { 'bad_key' => 'bad_value' } }
+
+        it 'redirects back with an alert due to invalid matched_topics' do
+          allow_any_instance_of(ReviewBidsController).to receive(:bidding_data).and_return(mock_input)
+          allow_any_instance_of(ReviewBidsController).to receive(:run_bidding_algorithm).and_return(invalid_mock_output)
+          allow_any_instance_of(ReviewBid).to receive(:assign_review_topics).with(invalid_mock_output).and_raise(StandardError)
+
+          post :assign_bidding, params: { assignment_id: assignment.id }
+
+          expect(response).to have_http_status(302)
+          expect(response).to redirect_to(root_path)
+          expect(flash[:alert]).to eq('Failed to assign reviewers. Please try again later.')
+        end
+      end
+
+      # TC05: ReviewBid.assign_review_topics Fails
+      context 'when topic or assignment is missing in assign_review_topics' do
+        let!(:reviewers) { create_list(:participant, 3, assignment: assignment) }
+
+        it 'redirects back with an alert for missing topic/assignment' do
+          # Mock to trigger `ArgumentError` for missing topic/assignment
+          allow_any_instance_of(ReviewBid).to receive(:assign_review_topics).and_raise(ArgumentError, 'Topic or assignment is missing')
+
+          post :assign_bidding, params: { assignment_id: assignment.id }
+
+          expect(response).to have_http_status(302)
+          expect(response).to redirect_to(root_path)
+          expect(flash[:alert]).to eq('Topic or assignment is missing')
+        end
+      end
+
+      # TC06: ReviewBid.assign_review_topics raises ActiveRecordError
+      context 'when ReviewBid.assign_review_topics raises ActiveRecordError' do
+        let!(:reviewers) { create_list(:participant, 3, assignment: assignment) }
+
+        it 'redirects back with an alert for database error' do
+          allow_any_instance_of(ReviewBid).to receive(:assign_review_topics).and_raise(ActiveRecord::ActiveRecordError)
+
+          post :assign_bidding, params: { assignment_id: assignment.id }
+
+          expect(response).to have_http_status(302)
+          expect(response).to redirect_to(root_path)
+          expect(flash[:alert]).to eq('Failed to assign reviewers due to database error. Please try again later.')
+        end
+      end
+
+      # TC07: ReviewBid.assign_review_topics raises an unexpected error
+      context 'when ReviewBid.assign_review_topics raises an unexpected error' do
+        let!(:reviewers) { create_list(:participant, 3, assignment: assignment) }
+
+        it 'redirects back with a generic alert' do
+          allow_any_instance_of(ReviewBid).to receive(:assign_review_topics).and_raise(StandardError)
+
+          post :assign_bidding, params: { assignment_id: assignment.id }
+
+          expect(response).to have_http_status(302)
+          expect(response).to redirect_to(root_path)
+          expect(flash[:alert]).to eq('Failed to assign reviewers. Please try again later.')
+        end
+      end
+
+    # TC08: Assignment.update Fails
+    context 'when assignment.update fails' do
+      let!(:reviewers) { create_list(:participant, 5, assignment: assignment) }
+      let!(:topics) { create_list(:sign_up_topic, 3, assignment: assignment) }
+
+      let(:mock_output) do
+        reviewers.index_by(&:id).transform_values { |_reviewer| topics.sample(3).map(&:id) }
+      end
+
+      it 'handles the exception and redirects back with an alert' do
+        allow(Assignment).to receive(:find).with(assignment.id.to_s).and_return(assignment)
+        allow_any_instance_of(ReviewBidsController).to receive(:bidding_data).and_return(mock_input)
+        allow_any_instance_of(ReviewBidsController).to receive(:run_bidding_algorithm).and_return(mock_output)
+        allow_any_instance_of(ReviewBid).to receive(:assign_review_topics).and_return(true)
+        expect(assignment).to receive(:update!).with(can_choose_topic_to_review: false).and_raise(ActiveRecord::RecordInvalid.new(assignment))
+
+        post :assign_bidding, params: { assignment_id: assignment.id }
+
+        expect(response).to have_http_status(302)
+        expect(response).to redirect_to(root_path)
+        expect(flash[:alert]).to eq('Failed to assign reviewers due to database error. Please try again later.')
+      end
+    end
+
+
+      # TC09: Empty bidding_data
+      context 'When bidding_data is empty' do
+        let!(:reviewers) { create_list(:participant, 5, assignment: assignment) }
+
+        it 'redirects back with an alert due to empty bidding_data' do
+          review_bid = instance_double('ReviewBid')
+          allow(ReviewBid).to receive(:new).and_return(review_bid)
+          allow(review_bid).to receive(:assign_review_topics).and_return(true)
+          allow(Assignment).to receive(:find).with(assignment.id.to_s).and_return(assignment)
+          allow_any_instance_of(ReviewBidsController).to receive(:bidding_data).and_return({})
+          allow_any_instance_of(ReviewBidsController).to receive(:run_bidding_algorithm).and_return(nil)
+
+          post :assign_bidding, params: { assignment_id: assignment.id }
+
+          expect(response).to have_http_status(302)
+          expect(response).to redirect_to(root_path)
+          expect(flash[:alert]).to eq('Topic or assignment is missing')
+        end
+      end
     end
   end
 end

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -14,8 +14,18 @@ FactoryBot.define do
   end 
 
   factory :review_bid, class: ReviewBid do
+    association :topic, factory: :sign_up_topic # Ensures valid topic association
+    association :participant, factory: :participant
     priority 2
-    signuptopic_id 123
+    # signuptopic_id 123
+  end
+
+  factory :sign_up_topic do
+    sequence(:topic_name) { |n| "topic#{n}" }
+    assignment { association(:assignment) }
+    max_choosers { 3 }
+    category { 'Test Category' }
+    sequence(:topic_identifier) { |n| "tid#{n}" }
   end
 
   factory :role_of_administrator, class: Role do
@@ -121,11 +131,13 @@ FactoryBot.define do
 
   factory :student, class: User do
     # Zhewei: In order to keep students the same names (2065, 2066, 2064) before each example.
-    sequence(:name) { |n| n = n % 3; "student206#{n + 4}" }
+    # sequence(:name) { |n| n = n % 3; "student206#{n + 4}" }
+    sequence(:name) { |n| "student#{n}" }
     role { Role.where(name: 'Student').first || association(:role_of_student) }
     password 'password'
     password_confirmation 'password'
-    sequence(:fullname) { |n| n = n % 3; "206#{n + 4}, student" }
+    # sequence(:fullname) { |n| n = n % 3; "206#{n + 4}, student" }
+    sequence(:fullname) { |n| "fullname#{n}" }
     email 'expertiza@mailinator.com'
     parent_id 1
     private_by_default  false
@@ -135,7 +147,7 @@ FactoryBot.define do
     email_on_review_of_review true
     is_new_user false
     master_permission_granted 0
-    handle 'handle'
+    sequence(:handle) { |n| "student_handle_#{n}" }
     digital_certificate nil
     timezonepref 'Eastern Time (US & Canada)'
     public_key nil
@@ -332,7 +344,7 @@ FactoryBot.define do
     penalty_accumulated 0
     grade nil
     type 'AssignmentParticipant'
-    handle 'handle'
+    sequence(:handle) { |n| "handle_#{n}" }
     time_stamp nil
     digital_signature nil
     can_mentor false


### PR DESCRIPTION
**Summary of Changes**

- Added `BiddingAlgorithmService`
- Moved Business logic for running algorithm service to `BiddingAlgorithmService' and using mock data since webservice is not working anymore as heroku is no longer used
- Updated `ReviewBidsController#assign_bidding` method to use service
- Added test cases for `ReviewBidsController#assign_bidding` method

---
About the Expertiza Bot
- If you have any questions about comments given by the expertiza-bot [(example)](https://github.com/expertiza/expertiza/pull/1877#issuecomment-762412918), you could create a new comment in your pull request with the content `/dispute [UUID1] [UUID2]` [(example)](https://github.com/expertiza/expertiza/pull/1877#issuecomment-762430057), then the professor and TAs will be notified.
- [Here is a video](https://tinyurl.com/internet-bots) about how to communicate to the expertiza-bot.
